### PR TITLE
Separate proxy support

### DIFF
--- a/jhub_apps/config_utils.py
+++ b/jhub_apps/config_utils.py
@@ -13,3 +13,7 @@ class JAppsConfig(SingletonConfigurable):
     python_exec = Unicode(
         "python", help="Python executable to use for running all the commands"
     ).tag(config=True)
+    origin_host = Unicode(
+        default_value="",
+        help="Host ip and port currently being used. Required for Bokeh to allow access."
+    ).tag(config=True)

--- a/jhub_apps/configuration.py
+++ b/jhub_apps/configuration.py
@@ -37,6 +37,7 @@ def install_jhub_apps(c, spawner_to_subclass):
                     "-m",
                     "flask",
                     "run",
+                    "--host=0.0.0.0",
                     "--port=10202",
                 ],
                 "environment": {"FLASK_APP": "jhub_apps.service.app"},
@@ -48,7 +49,7 @@ def install_jhub_apps(c, spawner_to_subclass):
                     c.JAppsConfig.python_exec,
                     "-m",
                     "jhub_apps.launcher.main",
-                    f"--origin-host={get_origin_host(c.JupyterHub.bind_url)}",
+                    f"--origin-host={get_origin_host(c.JAppsConfig.origin_host)}",
                 ],
                 # Remove this get, set environment properly
                 "api_token": os.environ.get(

--- a/jhub_apps/configuration.py
+++ b/jhub_apps/configuration.py
@@ -30,7 +30,7 @@ def install_jhub_apps(c, spawner_to_subclass):
         [
             {
                 "name": "japps",
-                "url": "http://127.0.0.1:10202",
+                "url": "http://0.0.0.0:10202",
                 # TODO: Run flask app behind gunicorn
                 "command": [
                     c.JAppsConfig.python_exec,
@@ -44,7 +44,7 @@ def install_jhub_apps(c, spawner_to_subclass):
             },
             {
                 "name": "launcher",
-                "url": "http://127.0.0.1:5000",
+                "url": "http://0.0.0.0:5000",
                 "command": [
                     c.JAppsConfig.python_exec,
                     "-m",

--- a/jhub_apps/spawner/utils.py
+++ b/jhub_apps/spawner/utils.py
@@ -1,10 +1,6 @@
-from urllib.parse import urlparse
-
-
 def get_origin_host(bind_url):
-    parsed_url = urlparse(bind_url)
-    if "0.0.0.0" in parsed_url.netloc:
+    if bind_url == "":
         # Hack: Useful for local development when using docker
         # Maybe take it from the user via JAppsConfig?
         return "127.0.0.1:8000"
-    return parsed_url.netloc
+    return bind_url


### PR DESCRIPTION
This is what I had to do in order to get it working with a separate configurable proxy  docker container with docker compose

This seems to be related to this issue: https://stackoverflow.com/questions/30554702/cant-connect-to-flask-web-service-connection-refused

I'm not particularly tied to how I re-implemented `get_origin_host`. It was a quick fix to get things working and I'm happy to make any changes there.