### PR TITLE
add configurable conda environment options, relaxes networking restrictions

### DIFF
--- a/jhub_apps/config_utils.py
+++ b/jhub_apps/config_utils.py
@@ -13,6 +13,11 @@ class JAppsConfig(SingletonConfigurable):
         "python", help="Python executable to use for running all the commands"
     ).tag(config=True)
 
+    allowed_hosts = Unicode(
+        "",
+        help="Hosts that are allowed to access launched apps. Defualts to hub_url"
+    ).tag(config=True)
+
     app_title = Unicode(
         "JHub Apps Launcher",
         help="Title to display on the Home Page of JHub Apps Launcher",

--- a/jhub_apps/configuration.py
+++ b/jhub_apps/configuration.py
@@ -45,6 +45,7 @@ def install_jhub_apps(c, spawner_to_subclass):
                     "flask",
                     "run",
                     "--port=10202",
+                    "--host=0.0.0.0",
                 ],
                 "environment": {
                     "FLASK_APP": "jhub_apps.service.app",

--- a/jhub_apps/configuration.py
+++ b/jhub_apps/configuration.py
@@ -37,7 +37,7 @@ def install_jhub_apps(c, spawner_to_subclass):
         [
             {
                 "name": "japps",
-                "url": "http://127.0.0.1:10202",
+                "url": "http://0.0.0.0:10202",
                 # TODO: Run flask app behind gunicorn
                 "command": [
                     c.JAppsConfig.python_exec,
@@ -54,12 +54,13 @@ def install_jhub_apps(c, spawner_to_subclass):
             },
             {
                 "name": "launcher",
-                "url": "http://127.0.0.1:5000",
+                "url": "http://0.0.0.0:5000",
                 "command": [
                     c.JAppsConfig.python_exec,
                     "-m",
                     "jhub_apps.launcher.main",
-                    f"--origin-host={get_origin_host(c.JupyterHub.bind_url)}",
+                    # f"--origin-host={get_origin_host(c.JupyterHub.bind_url)}",
+                    f"--origin-host=*",
                 ],
                 # Remove this get, set environment properly
                 "api_token": os.environ.get(

--- a/jhub_apps/configuration.py
+++ b/jhub_apps/configuration.py
@@ -29,6 +29,11 @@ def install_jhub_apps(c, spawner_to_subclass):
     if not isinstance(c.JAppsConfig.app_icon, str):
         c.JAppsConfig.app_icon = JAppsConfig.app_icon.default_value
 
+    if c.JAppsConfig.allowed_hosts == "":
+        allowed_hosts = get_origin_host(c.JupyterHub.bind_url)
+    else:
+        allowed_hosts = c.JAppsConfig.allowed_host
+
     if not isinstance(bind_url, str):
         raise ValueError(f"c.JupyterHub.bind_url is not set: {c.JupyterHub.bind_url}")
     if not c.JupyterHub.services:
@@ -60,8 +65,7 @@ def install_jhub_apps(c, spawner_to_subclass):
                     c.JAppsConfig.python_exec,
                     "-m",
                     "jhub_apps.launcher.main",
-                    # f"--origin-host={get_origin_host(c.JupyterHub.bind_url)}",
-                    f"--origin-host=*",
+                    f"--origin-host={allowed_hosts}",
                 ],
                 # Remove this get, set environment properly
                 "api_token": os.environ.get(

--- a/jhub_apps/launcher/panel_app.py
+++ b/jhub_apps/launcher/panel_app.py
@@ -118,6 +118,7 @@ class InputFormWidget:
     filepath_input: Any
     thumbnail: Any
     description_input: Any
+    conda_input: Any
     custom_command: Any
     spinner: Any
     button_widget: Any
@@ -334,6 +335,9 @@ def get_input_form_widget():
         description_input=pn.widgets.TextAreaInput(
             name="Description", css_classes=["custom-font"]
         ),
+        conda_input=pn.widgets.TextInput(
+            name="Conda Environment Path", css_classes=["custom-font"]
+        ),
         custom_command=pn.widgets.TextInput(
             name="Custom Command", css_classes=["custom-font"], visible=False
         ),
@@ -363,6 +367,7 @@ def get_input_form_widget():
         input_form_widget.thumbnail,
         input_form_widget.description_input,
         input_form_widget.framework,
+        input_form_widget.conda_input,
         input_form_widget.custom_command,
         input_form_widget.button_widget,
         width=400,
@@ -407,6 +412,7 @@ def _create_server(event, input_form_widget, input_form, username):
         thumbnail=thumbnail_local_filepath,
         filepath=filepath,
         framework=framework,
+        conda_env = input_form_widget.conda_input.value,
         custom_command=input_form_widget.custom_command.value,
     )
     try:

--- a/jhub_apps/launcher/panel_app.py
+++ b/jhub_apps/launcher/panel_app.py
@@ -412,7 +412,7 @@ def _create_server(event, input_form_widget, input_form, username):
         thumbnail=thumbnail_local_filepath,
         filepath=filepath,
         framework=framework,
-        conda_env = input_form_widget.conda_input.value,
+        conda_env=input_form_widget.conda_input.value,
         custom_command=input_form_widget.custom_command.value,
     )
     try:

--- a/jhub_apps/spawner/spawner_creation.py
+++ b/jhub_apps/spawner/spawner_creation.py
@@ -93,6 +93,7 @@ def subclass_spawner(base_spawner):
                     "jupyterhub.singleuser",
                 ]
             print(f"Final Spawner Command: {self.cmd}")
+            print(f"Final python path: {python_path}")
             return await super().start()
 
         def _get_python_path(self, conda_path_string):

--- a/jhub_apps/spawner/spawner_creation.py
+++ b/jhub_apps/spawner/spawner_creation.py
@@ -86,8 +86,6 @@ def subclass_spawner(base_spawner):
                     authtype=self.config.JAppsConfig.apps_auth_type,
                 )
 
-
-                
             if framework == Framework.jupyterlab.value:
                 self.cmd = [
                     python_path,

--- a/jhub_apps/spawner/spawner_creation.py
+++ b/jhub_apps/spawner/spawner_creation.py
@@ -75,22 +75,35 @@ def subclass_spawner(base_spawner):
 
         async def start(self):
             framework = self.user_options.get("framework")
+            python_path = self._get_python_path(self.user_options.get("conda_env"))
+
             if (
                 self.user_options.get("jhub_app")
                 and framework != Framework.jupyterlab.value
             ):
                 self.cmd = DEFAULT_CMD.get_substituted_args(
-                    python_exec=self.config.JAppsConfig.python_exec,
+                    python_exec=python_path,
                     authtype=self.config.JAppsConfig.apps_auth_type,
                 )
+
+
+                
             if framework == Framework.jupyterlab.value:
                 self.cmd = [
-                    self.config.JAppsConfig.python_exec,
+                    python_path,
                     "-m",
                     "jupyterhub.singleuser",
                 ]
             print(f"Final Spawner Command: {self.cmd}")
             return await super().start()
+
+        def _get_python_path(self, conda_path_string):
+            if conda_path_string != "":
+                python_path = f"{conda_path_string}/bin/python3"
+            else:
+                python_path = self.config.JAppsConfig.python_exec
+
+            return python_path
 
         def _expand_user_vars(self, string):
             """

--- a/jhub_apps/spawner/spawner_creation.py
+++ b/jhub_apps/spawner/spawner_creation.py
@@ -43,8 +43,11 @@ def subclass_spawner(base_spawner):
                     command = Command(args=GENERIC_ARGS + custom_cmd.split())
                 else:
                     command: Command = COMMANDS.get(framework)
+
+                python_path = self._get_python_path(self.user_options.get("conda_env"))
+
                 command_args = command.get_substituted_args(
-                    python_exec=self.config.JAppsConfig.python_exec,
+                    python_exec=python_path,
                     filepath=app_filepath,
                     origin_host=get_origin_host(self.config.JupyterHub.bind_url),
                     base_url=self.config.JupyterHub.bind_url,
@@ -75,25 +78,21 @@ def subclass_spawner(base_spawner):
 
         async def start(self):
             framework = self.user_options.get("framework")
-            python_path = self._get_python_path(self.user_options.get("conda_env"))
-
             if (
                 self.user_options.get("jhub_app")
                 and framework != Framework.jupyterlab.value
             ):
                 self.cmd = DEFAULT_CMD.get_substituted_args(
-                    python_exec=python_path,
+                    python_exec=self.config.JAppsConfig.python_exec,
                     authtype=self.config.JAppsConfig.apps_auth_type,
                 )
-
             if framework == Framework.jupyterlab.value:
                 self.cmd = [
-                    python_path,
+                    self.config.JAppsConfig.python_exec,
                     "-m",
                     "jupyterhub.singleuser",
                 ]
             print(f"Final Spawner Command: {self.cmd}")
-            print(f"Final python path: {python_path}")
             return await super().start()
 
         def _get_python_path(self, conda_path_string):

--- a/jhub_apps/spawner/types.py
+++ b/jhub_apps/spawner/types.py
@@ -17,6 +17,7 @@ class UserOptions:
     description: str
     thumbnail: str
     filepath: str
+    conda_env: str
     framework: str
     custom_command: typing.Optional[str] = None
     env: typing.Optional[dict] = None

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -9,5 +9,5 @@ from jupyterhub.auth import DummyAuthenticator
 c.JupyterHub.authenticator_class = DummyAuthenticator
 c.JupyterHub.log_level = 10
 
-c.JupyterHub.bind_url = "http://127.0.0.1:8000"
+c.JupyterHub.bind_url = "http://0.0.0.0:8000"
 c = install_jhub_apps(c, spawner_to_subclass=SimpleLocalProcessSpawner)


### PR DESCRIPTION
@aktech Some initial work on adding configurable conda environment support. At the moment it will default to the python_exec specified in the jupyterhub_config if no environment is specified

I also relaxed some of the networking restrictions to allow for a multi-docker setup. Let me know your thoughts on if we should leave these permissive for now or make them configurable. Currently I have them hard-coded.