### PR TITLE
Disable JupyterLab and move theme config to module

### DIFF
--- a/jhub_apps/spawner/types.py
+++ b/jhub_apps/spawner/types.py
@@ -69,11 +69,11 @@ FRAMEWORKS = [
         display_name="Gradio",
         logo="https://www.gradio.app/_app/immutable/assets/gradio.8a5e8876.svg",
     ),
-    FrameworkConf(
-        name=Framework.jupyterlab.value,
-        display_name="JupyterLab",
-        logo="https://upload.wikimedia.org/wikipedia/commons/thumb/3/38/Jupyter_logo.svg/1200px-Jupyter_logo.svg.png",
-    ),
+    # FrameworkConf(
+    #     name=Framework.jupyterlab.value,
+    #     display_name="JupyterLab",
+    #     logo="https://upload.wikimedia.org/wikipedia/commons/thumb/3/38/Jupyter_logo.svg/1200px-Jupyter_logo.svg.png",
+    # ),
     FrameworkConf(
         name=Framework.custom.value,
         display_name="Custom Command",

--- a/jhub_apps/themes/__init__.py
+++ b/jhub_apps/themes/__init__.py
@@ -1,0 +1,17 @@
+LOGO = "/services/japps/static/img/Nebari-Logo-Horizontal-Lockup-White-text.svg"
+
+DEFAULT_THEME = {
+    "logo": LOGO,
+    "primary_color": "#C316E9",
+    "primary_color_dark": "#79158a",
+    "secondary_color": "#18817A",
+    "secondary_color_dark": "#12635E",
+    "accent_color": "#eda61d",
+    "accent_color_dark": "#a16d14",
+    "text_color": "#1c1d26",
+    "h1_color": "#0f1015",
+    "h2_color": "#0f1015",
+    "navbar_text_color": "#ffffff",
+    "navbar_hover_color": "#20b1a8",
+    "navbar_color": "#1c1d26",
+}

--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -1,6 +1,6 @@
 from jupyterhub.spawner import SimpleLocalProcessSpawner
 
-from jhub_apps import theme_template_paths
+from jhub_apps import theme_template_paths, themes
 from jhub_apps.configuration import install_jhub_apps
 
 c = get_config()  # noqa
@@ -51,17 +51,5 @@ c.JupyterHub.template_vars = {
     "hub_title": "Welcome to Nebari",
     "hub_subtitle": "your open source data science platform",
     "welcome": "Running in dev mode",
-    "logo": "/services/japps/static/img/Nebari-Logo-Horizontal-Lockup-White-text.svg",
-    "primary_color": "#C316E9",
-    "primary_color_dark": "#79158a",
-    "secondary_color": "#18817A",
-    "secondary_color_dark": "#12635E",
-    "accent_color": "#eda61d",
-    "accent_color_dark": "#a16d14",
-    "text_color": "#1c1d26",
-    "h1_color": "#0f1015",
-    "h2_color": "#0f1015",
-    "navbar_text_color": "#ffffff",
-    "navbar_hover_color": "#20b1a8",
-    "navbar_color": "#1c1d26",
+    **themes.DEFAULT_THEME
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs
- [x] Move themes config to theme module
- [x]  Disable JupyterLab from frameworks

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
