### PR TITLE
Add caching for JupyterHub config

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -20,5 +20,6 @@ dependencies:
   - tornado>=5.1
   - traitlets
   - python-slugify
+  - cachetools
   - pip:
       - gradio

--- a/jhub_apps/service/utils.py
+++ b/jhub_apps/service/utils.py
@@ -1,6 +1,8 @@
 import base64
 import logging
 import os
+
+from cachetools import cached, TTLCache
 from unittest.mock import Mock
 
 import requests
@@ -12,8 +14,11 @@ from slugify import slugify
 
 
 logger = logging.getLogger(__name__)
+CACHE_JUPYTERHUB_CONFIG_TIMEOUT = 180
 
 
+# Cache JupyterHub config as it might be an expensive operation
+@cached(cache=TTLCache(maxsize=1024, ttl=CACHE_JUPYTERHUB_CONFIG_TIMEOUT))
 def get_jupyterhub_config():
     hub = JupyterHub()
     jhub_config_file_path = os.environ["JHUB_JUPYTERHUB_CONFIG"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "bokeh",
     "traitlets",
     "python-slugify",
+    "cachetools",
     "PyJWT",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

Fetching JupyterHub config could be an expensive operation. The timeout is small enough to not bother with outdated jupyterhub config and large enough to not hammer the server to fetch jupyterhub config non-stop. This can be changed in the future based on what makes sense.

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
