### PR TITLE
Fix OpenAPI docs rendering

### DIFF
--- a/jhub_apps/service/app.py
+++ b/jhub_apps/service/app.py
@@ -18,7 +18,7 @@ STATIC_DIR = Path(__file__).parent.parent / "static"
 
 app = FastAPI(
     title="JApps Service",
-    version=get_version(),
+    version=str(get_version()),
     ### Serve out Swagger from the service prefix (<hub>/services/:name/docs)
     openapi_url=router.prefix + "/openapi.json",
     docs_url=router.prefix + "/docs",

--- a/jhub_apps/tests/test_api.py
+++ b/jhub_apps/tests/test_api.py
@@ -156,3 +156,12 @@ def test_api_status(client):
     rjson = response.json()
     assert rjson["status"] == "ok"
     assert "version" in rjson
+
+
+def test_open_api_docs(client):
+    response = client.get(
+        "/openapi.json",
+    )
+    assert response.status_code == 200
+    rjson = response.json()
+    assert rjson['info']['version']


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

Fixing the following issue:

```python
  File "/Users/aktech/miniconda3/envs/jhub-apps-dev/lib/python3.11/site-packages/pydantic/main.py", line 164, in __init__
    __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
pydantic_core._pydantic_core.ValidationError: 1 validation error for OpenAPI
info.version
  Input should be a valid string [type=string_type, input_value=<Version('2024.1.5')>, input_type=Version]
    For further information visit https://errors.pydantic.dev/2.5/v/string_type
```



<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
