### PR TITLE
Favicon missing on Create App pages

### DIFF
--- a/jhub_apps/service/japps_routes.py
+++ b/jhub_apps/service/japps_routes.py
@@ -27,6 +27,8 @@ async def handle_apps(request: Request):
         {
             "request": request,
             "version_hash": now.strftime("%Y%m%d%H%M%S"),
+            "hub_title": config.get("hub_title", "JupyterHub"),
+            "favicon": theme.get("favicon", "/service/japps/static/favicon.ico"),
             **theme,
         },
     )

--- a/jhub_apps/templates/japps_custom.html
+++ b/jhub_apps/templates/japps_custom.html
@@ -2,8 +2,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>JupyterHub Apps</title>
+    <title>{{ hub_title}}</title>
     <link rel="stylesheet" href="/hub/static/css/style.min.css" />
+    <link rel="icon" href="{{ favicon }}" type="image/x-icon" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

Fixes #477 

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Screenshots
<img width="1728" alt="Screenshot 2024-09-13 at 3 34 27 PM" src="https://github.com/user-attachments/assets/4d5aabb4-9716-42f4-b837-49e40058734a">

## Any other comments?
- Updated japps custom page template to provide hub_title and favicon based on app configs, to match those used in the base page template.

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
