### PR TITLE
Add missing `bokeh_sampledata`

### DIFF
--- a/docs/docs/create-apps/panel-app.md
+++ b/docs/docs/create-apps/panel-app.md
@@ -108,6 +108,7 @@ dependencies:
   - jhsingle-native-proxy>=0.8.2
   - bokeh-root-cmd
   - nbconvert
+  - bokeh_sampledata
 ```
 
 </details>


### PR DESCRIPTION
## Reference Issues or PRs

With new `bokeh` version the example app no longer works as it requires `bokeh_sampledata` to be installed for this import to work:

```python
from bokeh.sampledata import iris
```

See https://docs.bokeh.org/en/latest/docs/reference/sampledata.html#bokeh-sampledata

And alternative approach would be to replace it with penguin data as in:
- https://github.com/bokeh/bokeh/pull/13749

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):
