### PR TITLE
Add GA4 tracking with GDPR cookie consent banner

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -34,11 +34,38 @@ const config = {
     locales: ['en'],
   },
 
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: {},
+      innerHTML:
+        "window.dataLayer = window.dataLayer || [];" +
+        "function gtag(){dataLayer.push(arguments);}" +
+        "gtag('consent', 'default', {" +
+        "  ad_storage: 'denied'," +
+        "  ad_user_data: 'denied'," +
+        "  ad_personalization: 'denied'," +
+        "  analytics_storage: 'denied'," +
+        "  functionality_storage: 'denied'," +
+        "  personalization_storage: 'denied'," +
+        "  security_storage: 'granted'," +
+        "  wait_for_update: 500" +
+        "});" +
+        "gtag('set', 'ads_data_redaction', true);",
+    },
+  ],
+
+  clientModules: ['./src/cookieConsent.js'],
+
   presets: [
     [
       'classic',
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
+        gtag: {
+          trackingID: 'G-NXNMX83GGS',
+          anonymizeIP: true,
+        },
         docs: {
           sidebarPath: './sidebars.js',
           // Please change this to your repo.

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,8 @@
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "vanilla-cookieconsent": "^3.1.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.1.0",

--- a/docs/src/cookieConsent.js
+++ b/docs/src/cookieConsent.js
@@ -1,0 +1,66 @@
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+if (ExecutionEnvironment.canUseDOM) {
+  (async () => {
+    const CookieConsent = await import('vanilla-cookieconsent');
+    await import('vanilla-cookieconsent/dist/cookieconsent.css');
+
+    const updateGtag = (analyticsGranted) => {
+      window.dataLayer = window.dataLayer || [];
+      const gtag = (...args) => window.dataLayer.push(args);
+      gtag('consent', 'update', {
+        analytics_storage: analyticsGranted ? 'granted' : 'denied',
+      });
+    };
+
+    CookieConsent.run({
+      guiOptions: {
+        consentModal: { layout: 'box', position: 'bottom right' },
+        preferencesModal: { layout: 'box' },
+      },
+      categories: {
+        necessary: { enabled: true, readOnly: true },
+        analytics: {},
+      },
+      language: {
+        default: 'en',
+        translations: {
+          en: {
+            consentModal: {
+              title: 'Cookie Consent',
+              description:
+                'We use cookies to analyze site traffic and improve your experience.',
+              acceptAllBtn: 'Accept all',
+              acceptNecessaryBtn: 'Reject all',
+              showPreferencesBtn: 'Manage preferences',
+            },
+            preferencesModal: {
+              title: 'Cookie preferences',
+              acceptAllBtn: 'Accept all',
+              acceptNecessaryBtn: 'Reject all',
+              savePreferencesBtn: 'Save preferences',
+              closeIconLabel: 'Close',
+              sections: [
+                {
+                  title: 'Strictly necessary',
+                  description:
+                    'These cookies are essential for the site to function and cannot be disabled.',
+                  linkedCategory: 'necessary',
+                },
+                {
+                  title: 'Analytics',
+                  description:
+                    'Help us understand how visitors use the site so we can improve it.',
+                  linkedCategory: 'analytics',
+                },
+              ],
+            },
+          },
+        },
+      },
+      onFirstConsent: () => updateGtag(CookieConsent.acceptedCategory('analytics')),
+      onChange: () => updateGtag(CookieConsent.acceptedCategory('analytics')),
+      onConsent: () => updateGtag(CookieConsent.acceptedCategory('analytics')),
+    });
+  })();
+}

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1484,7 +1484,7 @@
     "@docusaurus/theme-search-algolia" "3.1.0"
     "@docusaurus/types" "3.1.0"
 
-"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -6917,6 +6917,14 @@ react-loadable-ssr-addon-v5-slorber@^1.0.1:
   dependencies:
     "@babel/runtime" "^7.10.3"
 
+"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz#81aae0db81ecafbdaee3651f12804580868fa6ce"
+  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
+  dependencies:
+    "@types/react" "*"
+    prop-types "^15.6.2"
+
 react-router-config@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-router-config/-/react-router-config-5.1.1.tgz#0f4263d1a80c6b2dc7b9c1902c9526478194a988"
@@ -8075,6 +8083,11 @@ value-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
   integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
+
+vanilla-cookieconsent@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/vanilla-cookieconsent/-/vanilla-cookieconsent-3.1.0.tgz#0f430f4788e9a09e22e795088889b0679a88a263"
+  integrity sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Description

Adds Google Analytics (GA4) tracking to this site, gated behind a GDPR-compliant cookie consent banner. GA4 sets cookies that track visitors, so EU privacy law requires opt-in consent before any tracking fires.

## What does this implement/fix?

- [x] New feature (non-breaking change which adds a feature)

### What's included

- **Analytics:** GA4 via the shared Nebari property.
- **Consent:** opt-in banner gating all tracking.
- **Privacy-by-default:** no cookies set until the user accepts.

### Expected behavior

- On first visit, a consent banner appears in the bottom-right corner and no GA4 cookies are set.
- Two categories are exposed: **Strictly necessary** (always on) and **Analytics** (opt-in, controls GA4).
- Clicking **Accept all** enables GA4 tracking and remembers the choice.
- Clicking **Reject all** keeps tracking disabled; the banner does not reappear.
- Users can reopen **Manage preferences** later to change their choice, and GA4 updates immediately.