### PR TITLE
chore: bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Node environment
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.x
 

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Node environment
         uses: actions/setup-node@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,17 +15,17 @@ jobs:
         python-version: ["3.9"]
 
     steps:
-    # https://github.com/actions/checkout/releases/tag/v5.0.0
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+    # https://github.com/actions/checkout/releases/tag/v7.0.0
+    - uses: actions/checkout@v7
     - name: Setup Python
-      # https://github.com/actions/setup-python/releases/tag/v6.0.0
-      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+      # https://github.com/actions/setup-python/releases/tag/v6.3.0
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
     - name: Install uv
-      # https://github.com/astral-sh/setup-uv/releases/tag/v6.8.0
-      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+      # https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0
+      uses: astral-sh/setup-uv@v8
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Install uv
       # https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.2.0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,17 +15,14 @@ jobs:
         python-version: ["3.9"]
 
     steps:
-    # https://github.com/actions/checkout/releases/tag/v7.0.0
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Setup Python
-      # https://github.com/actions/setup-python/releases/tag/v6.3.0
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.12'
 
     - name: Install uv
-      # https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0
-      uses: astral-sh/setup-uv@v8.2.0
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        # https://github.com/actions/checkout/releases/tag/v5.0.0
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        # https://github.com/actions/checkout/releases/tag/v7.0.0
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        # https://github.com/actions/setup-python/releases/tag/v6.0.0
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+        # https://github.com/actions/setup-python/releases/tag/v6.3.0
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Install uv
-        # https://github.com/astral-sh/setup-uv/releases/tag/v6.8.0
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+        # https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0
+        uses: astral-sh/setup-uv@v8
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        # https://github.com/actions/checkout/releases/tag/v7.0.0
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Python
-        # https://github.com/actions/setup-python/releases/tag/v6.3.0
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.12'
 
       - name: Install uv
-        # https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install uv
         # https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Install uv
       # https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.2.0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -25,18 +25,15 @@ jobs:
           - "4.1.5"
           - "5.3.0"
     steps:
-    # https://github.com/actions/checkout/releases/tag/v7.0.0
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Setup Python
-      # https://github.com/actions/setup-python/releases/tag/v6.3.0
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      # https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0
-      uses: astral-sh/setup-uv@v8.2.0
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
     - name: Install dependencies
       run: |
@@ -106,16 +103,14 @@ jobs:
 
     - name: Upload Playwright Videos
       if: always()
-      # https://github.com/actions/upload-artifact/releases/tag/v7.0.1
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ steps.artifact-name.outputs.playwright-artifact-name }}
         path: videos
 
     - name: Upload JupyterHub logs
       if: always()
-      # https://github.com/actions/upload-artifact/releases/tag/v7.0.1
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ steps.artifact-name.outputs.jhub-logs-artifact-name }}
         path: jupyterhub-logs.txt

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -25,18 +25,18 @@ jobs:
           - "4.1.5"
           - "5.3.0"
     steps:
-    # https://github.com/actions/checkout/releases/tag/v5.0.0
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+    # https://github.com/actions/checkout/releases/tag/v7.0.0
+    - uses: actions/checkout@v7
 
     - name: Setup Python
-      # https://github.com/actions/setup-python/releases/tag/v6.0.0
-      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+      # https://github.com/actions/setup-python/releases/tag/v6.3.0
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      # https://github.com/astral-sh/setup-uv/releases/tag/v6.8.0
-      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+      # https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0
+      uses: astral-sh/setup-uv@v8
 
     - name: Install dependencies
       run: |
@@ -106,16 +106,16 @@ jobs:
 
     - name: Upload Playwright Videos
       if: always()
-      # https://github.com/actions/upload-artifact/releases/tag/v4.6.2
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      # https://github.com/actions/upload-artifact/releases/tag/v7.0.1
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ steps.artifact-name.outputs.playwright-artifact-name }}
         path: videos
 
     - name: Upload JupyterHub logs
       if: always()
-      # https://github.com/actions/upload-artifact/releases/tag/v4.6.2
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+      # https://github.com/actions/upload-artifact/releases/tag/v7.0.1
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ steps.artifact-name.outputs.jhub-logs-artifact-name }}
         path: jupyterhub-logs.txt

--- a/.github/workflows/test-k3s-integration.yml
+++ b/.github/workflows/test-k3s-integration.yml
@@ -29,15 +29,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Install Python dependencies
         run: uv sync --group test-jupyterhub-5 --extra dev
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-artifacts-k3s-py${{ matrix.python-version }}
           path: |

--- a/.github/workflows/test-k3s-integration.yml
+++ b/.github/workflows/test-k3s-integration.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Install Python dependencies
         run: uv sync --group test-jupyterhub-5 --extra dev

--- a/.github/workflows/test-k3s-integration.yml
+++ b/.github/workflows/test-k3s-integration.yml
@@ -29,15 +29,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8
 
       - name: Install Python dependencies
         run: uv sync --group test-jupyterhub-5 --extra dev
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-artifacts-k3s-py${{ matrix.python-version }}
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Install uv
       # https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v8.2.0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,18 +22,18 @@ jobs:
           - "==4.1.5"
           - ">=5.0.0"
     steps:
-    # https://github.com/actions/checkout/releases/tag/v5.0.0
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+    # https://github.com/actions/checkout/releases/tag/v7.0.0
+    - uses: actions/checkout@v7
 
     - name: Setup Python
-      # https://github.com/actions/setup-python/releases/tag/v6.0.0
-      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
+      # https://github.com/actions/setup-python/releases/tag/v6.3.0
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      # https://github.com/astral-sh/setup-uv/releases/tag/v6.8.0
-      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e
+      # https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0
+      uses: astral-sh/setup-uv@v8
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,18 +22,15 @@ jobs:
           - "==4.1.5"
           - ">=5.0.0"
     steps:
-    # https://github.com/actions/checkout/releases/tag/v7.0.0
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Setup Python
-      # https://github.com/actions/setup-python/releases/tag/v6.3.0
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      # https://github.com/astral-sh/setup-uv/releases/tag/v8.2.0
-      uses: astral-sh/setup-uv@v8.2.0
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Summary

Bumps all GitHub Actions under `.github/workflows/` to their latest stable major versions so they run on Node 24. GitHub is [deprecating Node 20 on Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) (runners default to Node 24 on 2026-06-16; Node 20 fully removed in Fall 2026). Actions still on old majors emit deprecation warnings now and break once Node 20 is gone.

Version bumps:

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 / v5 (SHA) / v6 | **v7** |
| `actions/setup-python` | v5 / v6 (SHA) | **v6** |
| `actions/setup-node` | v6 | v6 (already latest) |
| `actions/upload-artifact` | v4 / v4.6.2 (SHA) | **v7** |
| `astral-sh/setup-uv` | v5 / v6.8.0 (SHA) | **v8** |

Workflows touched: `build-ui.yml`, `lint.yml`, `release.yml`, `test.yml`, `test-integration.yml`, `test-k3s-integration.yml`. Stale `releases/tag/...` reference comments updated to match.

This is a version-bump-only change — no workflow logic, job topology, or trigger changes.

## Out of scope

Per the issue: re-pinning actions to commit SHAs + Dependabot/Renovate setup (separate follow-up), and upgrading runtimes used *inside* jobs.

Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)