### PR TITLE
Pin tailwindcss to v3.x in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,5 +40,12 @@ updates:
         versions:
           - ">=7.0.0"
       - dependency-name: "@mui/lab"
+      # v4 is a rewrite: the PostCSS plugin moved packages, the JS config is no
+      # longer auto-discovered, and `important: true` (which exists to beat
+      # JupyterHub's bundled Bootstrap 5) changes shape. Needs a deliberate
+      # migration, not a version bump.
+      - dependency-name: "tailwindcss"
+        versions:
+          - ">=4.0.0"
       - dependency-name: "@rollup/rollup-linux-x64-gnu"
       - dependency-name: "@esbuild/linux-x64"


### PR DESCRIPTION
Follow-up to closing #712.

Dependabot opened #712 bumping `tailwindcss` 3.4.19 → 4.3.3 as a plain version bump. v4 is a rewrite and `ui/` is still configured entirely for v3, so the build failed at `vite:css` on every CSS file:

```
[postcss] It looks like you're trying to use `tailwindcss` directly as a PostCSS plugin.
The PostCSS plugin has moved to a separate package...
```

This adds a `>=4.0.0` ignore rule so the major does not come back as a recurring broken PR. `^3.4.19` in `ui/package.json` already can't resolve to 4.x on its own — the caret is major-safe — so the ignore rule is the durable part.

### What a real v4 migration needs

- `postcss.config.js` — `tailwindcss` → `@tailwindcss/postcss` (and drop `autoprefixer`, now built in), or switch to `@tailwindcss/vite`
- `src/index.css` — `@tailwind base/components/utilities` → `@import "tailwindcss"`
- `tailwind.config.js` — no longer auto-discovered; the theme (MUI breakpoints, reduced type scale, shadcn `hsl(var(--x))` tokens, brand palette, radii, accordion keyframes) moves to `@theme` or gets pulled in via `@config`
- `important: true` — exists specifically to beat JupyterHub's bundled Bootstrap 5 `!important` utilities; v4 changes this to `@import "tailwindcss" important;`. Losing it breaks theming at runtime inside JupyterHub, which nothing here covers with tests — this is the highest-risk item and needs visual verification in a real hub page.
- `tailwindcss-animate` — v3 JS plugin; needs `@plugin` or a move to `tw-animate-css`

### Verification

`npm ci && npm run build` in `ui/` at v3.4.19 — green, `✓ built in 790ms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)