### PR TITLE
Upgrade TypeScript from 5.9.3 to 6.0.3

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -53,7 +53,7 @@
         "tailwindcss": "^3.4.19",
         "tailwindcss-animate": "^1.0.7",
         "tsconfig-paths": "4.2.0",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "vite": "8.1.5",
         "vite-plugin-environment": "1.1.3",
         "vite-tsconfig-paths": "6.1.1",
@@ -5101,26 +5101,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/tsconfck": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.0.3.tgz",
-      "integrity": "sha512-4t0noZX9t6GcPTfBAbIbbIU4pfpCwh0ueq3S4O/5qXI1VwK1outmxhe9dOiEWqMz3MW2LKgDTpqWV+37IWuVbA==",
-      "dev": true,
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
@@ -5151,9 +5131,9 @@
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5362,6 +5342,44 @@
       },
       "peerDependencies": {
         "vite": "*"
+      }
+    },
+    "node_modules/vite-tsconfig-paths/node_modules/tsconfck": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
+      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "deprecated": "unmaintained",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/vite/node_modules/picomatch": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -67,7 +67,7 @@
     "tailwindcss": "^3.4.19",
     "tailwindcss-animate": "^1.0.7",
     "tsconfig-paths": "4.2.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vite": "8.1.5",
     "vite-plugin-environment": "1.1.3",
     "vite-tsconfig-paths": "6.1.1",


### PR DESCRIPTION
Replaces #710.

Dependabot proposed 5.9.3 → 7.0.2, skipping the 6.x line entirely. TypeScript 7 is the native port with a new compiler implementation, and 6.0 is the JS-based release that surfaces the deprecations and behavior changes 7 builds on. Stepping through the latest 6.x first means deprecation fixes land against the compiler we already build with, instead of being debugged at the same time as a compiler swap.

`6.0.3` is the latest stable 6.x on npm (`7.0.2` currently holds the `latest` tag).

### Changes

- `ui/package.json` — `typescript` `5.9.3` → `6.0.3`
- `ui/package-lock.json` — regenerated

No source, `tsconfig.json`, or build-config changes were needed.

Pinned exactly rather than with a caret, matching how the other build-toolchain deps (`vite`, `vitest`, `@biomejs/biome`, `typescript` previously) are pinned in this file.

### Verification

Run in `ui/` at `typescript@6.0.3`:

| Check | Result |
| --- | --- |
| `npx tsc` | clean, no errors |
| `npm run build` | ✓ built in 515ms |
| `npm run test` | 27 files, 245 tests passed |
| `npm run ci` (biome) | exit 0 |

Bundle output is byte-identical to the 5.9.3 baseline (`index-C5mL0oNz.js`, 1,268.31 kB), as expected for a type-only change — emit comes from Vite, not `tsc`.

The one `biome ci` info notice (`biome.json` schema says 2.5.2, installed 2.5.6) is pre-existing on `main` and unrelated.

### Follow-up

Dependabot will re-open the 7.0.2 bump on its next monthly run. If TS 7 should wait until the toolchain (`vite`, `@vitejs/plugin-react`, `vite-tsconfig-paths`, `biome`, `vitest`) is confirmed ready, a `typescript >= 7.0.0` ignore rule in `.github/dependabot.yml` would hold it — #715 is already touching that file. Not included here to keep this PR to the upgrade itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)